### PR TITLE
Add support for bytea binary data type.

### DIFF
--- a/pgmoon/init.moon
+++ b/pgmoon/init.moon
@@ -58,6 +58,7 @@ ERROR_TYPES = flipped {
 
 PG_TYPES = {
   [16]: "boolean"
+  [17]: "bytea"
 
   [20]: "number" -- int8
   [21]: "number" -- int2
@@ -84,6 +85,9 @@ class Postgres
     json: (val, name) =>
       json = require "cjson"
       json.decode val
+
+    bytea: (val, name) =>
+      @decode_bytea val
   }
 
   new: (opts) =>
@@ -403,6 +407,17 @@ class Postgres
       else
         error "don't know how to encode #{bytes} byte(s)"
 
+  decode_bytea: (str) =>
+    if str\sub(1, 2) == '\\x'
+      str\sub(3)\gsub '..', (hex) ->
+        string.char tonumber hex, 16
+    else
+      str\gsub '\\(%d%d%d)', (oct) ->
+        string.char tonumber oct, 8
+
+  encode_bytea: (str) =>
+    string.format "E'\\\\x%s'", str\gsub '.', (byte) ->
+        string.format '%02x', string.byte byte
 
   escape_identifier: (ident) =>
     '"' ..  (tostring(ident)\gsub '"', '""') .. '"'

--- a/spec/pgmoon_spec.moon
+++ b/spec/pgmoon_spec.moon
@@ -225,6 +225,7 @@ describe "pgmoon with server", ->
         count integer default 100,
         flag boolean default false,
         count2 double precision default 1.2,
+        bytes bytea default E'\\x68656c6c6f5c20776f726c6427',
 
         primary key (id)
       )
@@ -247,6 +248,7 @@ describe "pgmoon with server", ->
         count: 100
         flag: false
         count2: 1.2
+        bytes: 'hello\\ world\''
       }
     }, res
 
@@ -265,6 +267,12 @@ describe "pgmoon with server", ->
     pg.NULL = n
     res = assert pg\query "select null the_null"
     assert n == res[1].the_null
+
+  it "should encode bytea type", ->
+    n = { { bytea: "encoded' string\\" } }
+    enc = pg\encode_bytea n[1].bytea
+    res = assert pg\query "select #{enc}::bytea"
+    assert.same n, res
 
   it "should return error message", ->
     status, err = pg\query "select * from blahlbhabhabh"


### PR DESCRIPTION
Includes `pg\encode_bytea` for encoding into hex format and `pg\decode_bytea` for decoding from both hex and escape formats (see http://www.postgresql.org/docs/current/static/datatype-binary.html)