### PR TITLE
fix "invalid password packet size" warning in log

### DIFF
--- a/pgmoon/init.lua
+++ b/pgmoon/init.lua
@@ -111,6 +111,7 @@ tobool = function(str)
 end
 local Postgres
 do
+  local _class_0
   local _base_0 = {
     convert_null = false,
     NULL = {
@@ -205,7 +206,8 @@ do
       assert(self.password, "missing password, required for connect")
       self:send_message(MSG_TYPE.password, {
         "md5",
-        md5(md5(self.password .. self.user) .. salt)
+        md5(md5(self.password .. self.user) .. salt),
+        "\0"
       })
       local t
       t, msg = self:receive_message()
@@ -531,7 +533,7 @@ do
     end
   }
   _base_0.__index = _base_0
-  local _class_0 = setmetatable({
+  _class_0 = setmetatable({
     __init = function(self, opts)
       if opts then
         self.user = opts.user

--- a/pgmoon/init.moon
+++ b/pgmoon/init.moon
@@ -182,7 +182,8 @@ class Postgres
 
     @send_message MSG_TYPE.password, {
       "md5"
-      md5 md5(@password .. @user) .. salt
+      md5 md5(@password .. @user) .. salt,
+      "\0"
     }
 
     t, msg = @receive_message!


### PR DESCRIPTION
The following is logged to `/var/log/postgresql/postgresql-9.3-main.log`:
```
LOG:  invalid password packet size
```
This commit removes this message from the postgresql log.

Source of the patch: https://git.io/vzWG8

fix #4