### PR TITLE
feat: enable usage in init_by_lua context

### DIFF
--- a/pgmoon/arrays.lua
+++ b/pgmoon/arrays.lua
@@ -1,8 +1,9 @@
 local PostgresArray
 do
+  local _class_0
   local _base_0 = { }
   _base_0.__index = _base_0
-  local _class_0 = setmetatable({
+  _class_0 = setmetatable({
     __init = function() end,
     __base = _base_0,
     __name = "PostgresArray"

--- a/pgmoon/init.lua
+++ b/pgmoon/init.lua
@@ -1,7 +1,6 @@
+local socket = require("pgmoon.socket")
 local insert
 insert = table.insert
-local tcp
-tcp = require("pgmoon.socket").tcp
 local rshift, lshift, band
 do
   local _obj_0 = require("bit")
@@ -111,6 +110,7 @@ tobool = function(str)
 end
 local Postgres
 do
+  local _class_0
   local _base_0 = {
     convert_null = false,
     NULL = {
@@ -144,7 +144,7 @@ do
       end
     },
     connect = function(self)
-      self.sock = tcp()
+      self.sock = socket.new()
       local ok, err = self.sock:connect(self.host, self.port)
       if not (ok) then
         return nil, err
@@ -531,7 +531,7 @@ do
     end
   }
   _base_0.__index = _base_0
-  local _class_0 = setmetatable({
+  _class_0 = setmetatable({
     __init = function(self, opts)
       if opts then
         self.user = opts.user

--- a/pgmoon/init.moon
+++ b/pgmoon/init.moon
@@ -1,6 +1,5 @@
+socket = require "pgmoon.socket"
 import insert from table
-import tcp from require "pgmoon.socket"
-
 import rshift, lshift, band from require "bit"
 
 VERSION = "1.2.0"
@@ -129,7 +128,7 @@ class Postgres
       @password = opts.password
 
   connect: =>
-    @sock = tcp!
+    @sock = socket.new!
     ok, err = @sock\connect @host, @port
     return nil, err unless ok
 

--- a/pgmoon/socket.lua
+++ b/pgmoon/socket.lua
@@ -1,55 +1,62 @@
-if ngx then
-  return {
-    tcp = ngx.socket.tcp
+local luasocket
+if not ngx then
+  local socket = require("socket")
+  local __flatten
+  __flatten = function(t, buffer)
+    local _exp_0 = type(t)
+    if "string" == _exp_0 then
+      buffer[#buffer + 1] = t
+    elseif "table" == _exp_0 then
+      for _index_0 = 1, #t do
+        local thing = t[_index_0]
+        __flatten(thing, buffer)
+      end
+    end
+  end
+  local _flatten
+  _flatten = function(t)
+    local buffer = { }
+    __flatten(t, buffer)
+    return table.concat(buffer)
+  end
+  local proxy_mt = {
+    __index = function(self, key)
+      local sock = self.sock
+      local original = sock[key]
+      if type(original) == "function" then
+        local fn
+        fn = function(_, ...)
+          return original(sock, ...)
+        end
+        self[key] = fn
+        return fn
+      else
+        return original
+      end
+    end
+  }
+  luasocket = {
+    tcp = function(...)
+      local sock = socket.tcp(...)
+      local proxy = setmetatable({
+        sock = sock,
+        send = function(self, ...)
+          return self.sock:send(_flatten(...))
+        end,
+        getreusedtimes = function(self)
+          return 0
+        end
+      }, proxy_mt)
+      return proxy
+    end
   }
 end
-local __flatten
-__flatten = function(t, buffer)
-  local _exp_0 = type(t)
-  if "string" == _exp_0 then
-    buffer[#buffer + 1] = t
-  elseif "table" == _exp_0 then
-    for _index_0 = 1, #t do
-      local thing = t[_index_0]
-      __flatten(thing, buffer)
-    end
-  end
-end
-local _flatten
-_flatten = function(t)
-  local buffer = { }
-  __flatten(t, buffer)
-  return table.concat(buffer)
-end
-local socket = require("socket")
-local proxy_mt = {
-  __index = function(self, key)
-    local sock = self.sock
-    local original = sock[key]
-    if type(original) == "function" then
-      local fn
-      fn = function(_, ...)
-        return original(sock, ...)
-      end
-      self[key] = fn
-      return fn
-    else
-      return original
-    end
-  end
-}
 return {
-  tcp = function(...)
-    local sock = socket.tcp(...)
-    local proxy = setmetatable({
-      sock = sock,
-      send = function(self, ...)
-        return self.sock:send(_flatten(...))
-      end,
-      getreusedtimes = function(self)
-        return 0
-      end
-    }, proxy_mt)
-    return proxy
+  new = function()
+    if ngx and ngx.get_phase() ~= "init" then
+      return ngx.socket.tcp()
+    else
+      return luasocket.tcp()
+    end
   end
 }

--- a/pgmoon/socket.moon
+++ b/pgmoon/socket.moon
@@ -1,46 +1,55 @@
+local luasocket
 
-if ngx
-  return { tcp: ngx.socket.tcp }
+-- Fallback to LuaSocket is only required when pgmoon
+-- runs in plain Lua, or in the init_by_lua context.
+if not ngx or ngx and ngx.get_phase! == "init"
+  socket = require "socket"
 
--- make luasockets send behave like openresty's
-__flatten = (t, buffer) ->
-  switch type(t)
-    when "string"
-      buffer[#buffer + 1] = t
-    when "table"
-      for thing in *t
-        __flatten thing, buffer
+  -- make luasockets send behave like openresty's
+  __flatten = (t, buffer) ->
+    switch type(t)
+      when "string"
+        buffer[#buffer + 1] = t
+      when "table"
+        for thing in *t
+          __flatten thing, buffer
 
 
-_flatten = (t) ->
-  buffer = {}
-  __flatten t, buffer
-  table.concat buffer
+  _flatten = (t) ->
+    buffer = {}
+    __flatten t, buffer
+    table.concat buffer
 
-socket = require "socket"
+  proxy_mt = {
+    __index: (key) =>
+      sock = @sock
+      original = sock[key]
+      if type(original) == "function"
+        fn = (_, ...) ->
+          original sock, ...
+        @[key] = fn
+        fn
+      else
+        original
+  }
 
-proxy_mt = {
-  __index: (key) =>
-    sock = @sock
-    original = sock[key]
-    if type(original) == "function"
-      fn = (_, ...) ->
-        original sock, ...
-      @[key] = fn
-      fn
-    else
-      original
-}
+  luasocket = {
+    tcp: (...) ->
+      sock = socket.tcp ...
+      proxy = setmetatable {
+        :sock
+        send: (...) => @sock\send _flatten ...
+        getreusedtimes: => 0
+      }, proxy_mt
+
+      proxy
+  }
 
 {
-  tcp: (...) ->
-    sock = socket.tcp ...
-    proxy = setmetatable {
-      :sock
-      send: (...) => @sock\send _flatten ...
-      getreusedtimes: => 0
-    }, proxy_mt
-
-    proxy
+  new: ->
+    if ngx and ngx.get_phase! != "init"
+      ngx.socket.tcp!
+    else
+      luasocket.tcp!
 }
 


### PR DESCRIPTION
Hey there!

I wanted to comment on #11 but at the same time, the trickiness of 
the patch made me want not to come empty-handed to the discussion. 

So here is a patch enabling the use of pgmoon in the `init_by_lua` 
context. It is a handy feature to have since performing queries before
the workers start could be much simpler than having to deal with
concurrency issues in `init_worker_by_lua`. As I am not extremely
familiar with Moonscript, please excuse inconsistencies with the
existing code style if any, I will fix them if this change is considered.

#### Changes

The trick to enabling the use inside of `init_by_lua` is to
fallback to Luasocket without being stuck with it in future contexts,
which means we must check whether cosockets are supported every
time we are trying to create one.

If we leave the previous behavior, and check for the availability of
cosockets at the module level, like so:

```lua
if ngx and ngx.get_phase() == "init" then
  -- return the luasocket constructor
else
  -- return the cosocket constructor
end
```

Now pgmoon will always create a luasocket instead of a cosocket in
future contexts, since the module is required only once.

Hence, we must ensure of the availability of cosockets in future calls
to `query()`, in order to not be stuck to using luasocket.

However, we do not want users using pgmoon only in the cosocket-enabled
contexts to depend on Luasocket. This dependency is only required when:

- pgmoon runs in plain Lua
- pgmoon runs in `init_by_lua`

Hence, we only `require()` Luasocket when one of those two condition
arises.