### PR TITLE
feat: encode_json and jsonb support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,9 @@ before_install:
 install:
   - luarocks install https://luarocks.org/manifests/olivine-labs/busted-2.0.rc11-0.rockspec
   - luarocks install moonscript
+  - luarocks install lua-cjson
   - luarocks make
 
-script: 
+script:
   - busted
 

--- a/README.md
+++ b/README.md
@@ -204,7 +204,8 @@ convert any Postgres types into the appropriate Lua type.
 
 All integer, floating point, and numeric types are converted into Lua's number
 type. The boolean type is converted into a Lua boolean. The JSON type is
-decoded into a Lua table using Lua CJSON.
+decoded into a Lua table using Lua CJSON. Lua tables can be encoded to JSON as
+described below.
 
 Any array types are automatically converted to Lua array tables. If you need to
 encode an array in Lua to Postgres' array syntax you can use the
@@ -230,6 +231,23 @@ local my_array = {1,2,3,4,5}
 pg:query("insert into some_table (some_arr_col) values(" .. encode_array(my_array) .. ")")
 ```
 
+## Handling JSON
+
+`json` and `jsonb` types are automatically decoded when they are returned from
+a query.
+
+Use `encode_json` to encode a Lua table to the JSON syntax for a query:
+
+```lua
+local pgmoon = require("pgmoon")
+local pg = pgmoon.new(auth)
+pg:connect()
+
+local encode_json = require("pgmoon.json").encode_json
+local my_tbl = {hello = "world"}
+pg:query("insert into some_table (some_json_col) values(" .. encode_json(my_tbl) .. ")")
+```
+
 ## Converting `NULL`s
 
 By default `NULL`s in Postgres are converted to `nil`, meaning they aren't
@@ -253,9 +271,9 @@ OpenResty you might want to reuse `ngx.null`.
 
 # Contact
 
-Author: Leaf Corcoran (leafo) ([@moonscript](http://twitter.com/moonscript))  
-Email: leafot@gmail.com  
-Homepage: <http://leafo.net>  
+Author: Leaf Corcoran (leafo) ([@moonscript](http://twitter.com/moonscript))
+Email: leafot@gmail.com
+Homepage: <http://leafo.net>
 
 
 # Changelog

--- a/pgmoon-dev-1.rockspec
+++ b/pgmoon-dev-1.rockspec
@@ -26,6 +26,7 @@ build = {
     ["pgmoon.arrays"] = "pgmoon/arrays.lua",
     ["pgmoon.crypto"] = "pgmoon/crypto.lua",
     ["pgmoon.socket"] = "pgmoon/socket.lua",
+    ["pgmoon.json"] = "pgmoon/json.lua"
   },
 }
 

--- a/pgmoon/init.lua
+++ b/pgmoon/init.lua
@@ -101,7 +101,8 @@ local PG_TYPES = {
   [1015] = "array_string",
   [1002] = "array_string",
   [1014] = "array_string",
-  [114] = "json"
+  [114] = "json",
+  [3802] = "json"
 }
 local NULL = "\0"
 local tobool

--- a/pgmoon/init.lua
+++ b/pgmoon/init.lua
@@ -121,8 +121,9 @@ do
     port = "5432",
     type_deserializers = {
       json = function(self, val, name)
-        local json = require("cjson")
-        return json.decode(val)
+        local decode_json
+        decode_json = require("pgmoon.json").decode_json
+        return decode_json(val)
       end,
       bytea = function(self, val, name)
         return self:decode_bytea(val)

--- a/pgmoon/init.moon
+++ b/pgmoon/init.moon
@@ -81,7 +81,8 @@ PG_TYPES = {
   [1002]: "array_string" -- char array
   [1014]: "array_string" -- bpchar array
 
-  [114]: "json"
+  [114]: "json" -- json
+  [3802]: "json" -- jsonb
 }
 
 NULL = "\0"

--- a/pgmoon/init.moon
+++ b/pgmoon/init.moon
@@ -100,8 +100,8 @@ class Postgres
   -- custom types supplementing PG_TYPES
   type_deserializers: {
     json: (val, name) =>
-      json = require "cjson"
-      json.decode val
+      import decode_json from require "pgmoon.json"
+      decode_json val
 
     bytea: (val, name) =>
       @decode_bytea val

--- a/pgmoon/json.lua
+++ b/pgmoon/json.lua
@@ -1,0 +1,25 @@
+local default_escape_literal = nil
+local encode_json
+encode_json = function(tbl, escape_literal)
+  escape_literal = escape_literal or default_escape_literal
+  local json = require("cjson")
+  if not (escape_literal) then
+    local Postgres
+    Postgres = require("pgmoon").Postgres
+    default_escape_literal = function(v)
+      return Postgres.escape_literal(nil, v)
+    end
+    escape_literal = default_escape_literal
+  end
+  local enc = json.encode(tbl)
+  return escape_literal(enc)
+end
+local decode_json
+decode_json = function(str)
+  local json = require("cjson")
+  return json.decode(str)
+end
+return {
+  encode_json = encode_json,
+  decode_json = decode_json
+}

--- a/pgmoon/json.moon
+++ b/pgmoon/json.moon
@@ -1,0 +1,21 @@
+default_escape_literal = nil
+
+encode_json = (tbl, escape_literal) ->
+  escape_literal or= default_escape_literal
+  json = require "cjson"
+
+  unless escape_literal
+    import Postgres from require "pgmoon"
+    default_escape_literal = (v) ->
+      Postgres.escape_literal nil, v
+
+    escape_literal = default_escape_literal
+
+  enc = json.encode tbl
+  escape_literal enc
+
+decode_json = (str) ->
+  json = require "cjson"
+  json.decode str
+
+{ :encode_json, :decode_json }

--- a/spec/pgmoon_spec.moon
+++ b/spec/pgmoon_spec.moon
@@ -227,6 +227,7 @@ describe "pgmoon with server", ->
         count2 double precision default 1.2,
         bytes bytea default E'\\x68656c6c6f5c20776f726c6427',
         config json default '{"hello": "world", "arr": [1,2,3], "nested": {"foo": "bar"}}',
+        bconfig jsonb default '{"hello": "world", "arr": [1,2,3], "nested": {"foo": "bar"}}',
 
         primary key (id)
       )
@@ -251,6 +252,7 @@ describe "pgmoon with server", ->
         count2: 1.2
         bytes: 'hello\\ world\''
         config: { hello: "world", arr: {1,2,3}, nested: {foo: "bar"} }
+        bconfig: { hello: "world", arr: {1,2,3}, nested: {foo: "bar"} }
       }
     }, res
 


### PR DESCRIPTION
Hi there,

This is a proposition for some more native JSON support in pgmoon.

Mainly two changes here:

First, more native support for JSON with `encode_json` which,
just like decoding, uses CJSON (with surrounding quotes and escaping)
and some deserialization tests that were missing.

Secondly, jsonb type support as pointed out by #15, which simply is
the addition of a new deserializer type. You might have reasons as for
why it was not previously added, hence why this is in a separate commit
in case it is not desired.

Let me know what you think
