### PR TITLE
chore(makefile) add build rule and run it before test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
+.PHONY: build test local show_types lint
 
-.PHONY: test local show_types lint
+build:
+	moonc pgmoon
 
-test:
-	busted
+test: build
+	busted -v
 
 local:
 	tup upd


### PR DESCRIPTION
I just find it handy, could be of some use to other contributors.

The 'test' rule also uses -v in case of errors.