### PR TITLE
feat: implement support for SSL connection

### DIFF
--- a/pgmoon/init.moon
+++ b/pgmoon/init.moon
@@ -97,6 +97,7 @@ class Postgres
   user: "postgres"
   host: "127.0.0.1"
   port: "5432"
+  ssl: false
 
   -- custom types supplementing PG_TYPES
   type_deserializers: {
@@ -127,6 +128,14 @@ class Postgres
       @database = opts.database
       @port = opts.port
       @password = opts.password
+      @ssl = opts.ssl
+      @ssl_verify = opts.ssl_verify
+      @ssl_required = opts.ssl_required
+      @luasec_opts = {
+        key: opts.key
+        cert: opts.cert
+        cafile: opts.cafile
+      }
 
   connect: =>
     @sock = socket.new!
@@ -134,8 +143,13 @@ class Postgres
     return nil, err unless ok
 
     if @sock\getreusedtimes! == 0
+      if @ssl
+        success, err = @send_ssl_message!
+        return nil, err unless success
+
       success, err = @send_startup_message!
       return nil, err unless success
+
       success, err = @auth!
       return nil, err unless success
 
@@ -419,6 +433,24 @@ class Postgres
       @encode_int _len(data) + 4
       data
     }
+
+  send_ssl_message: =>
+    success, err = @sock\send {
+      @encode_int 8,
+      @encode_int 80877103
+    }
+    return nil, err unless success
+
+    t, err = @sock\receive 1
+    return nil, err unless t
+
+    if t == MSG_TYPE.status
+      @sock\sslhandshake false, nil, @ssl_verify, nil, @luasec_opts
+    elseif t == MSG_TYPE.error or @ssl_required
+      @disconnect!
+      nil, "the server does not support SSL connections"
+    else
+      true -- no SSL support, but not required by client
 
   send_message: (t, data, len=nil) =>
     len = _len data if len == nil

--- a/spec/pgmoon_spec.moon
+++ b/spec/pgmoon_spec.moon
@@ -37,6 +37,33 @@ describe "pgmoon with server", ->
 
     assert.same true, res
 
+  it "tries to connect with SSL", ->
+    -- we expect a server with ssl = off
+    ssl_pg = Postgres {
+      database: DB
+      user: USER
+      host: HOST
+      ssl: true
+    }
+
+    finally ->
+      ssl_pg\disconnect!
+
+    assert ssl_pg\connect!
+
+  it "requires SSL", ->
+    ssl_pg = Postgres {
+      database: DB
+      user: USER
+      host: HOST
+      ssl: true
+      ssl_required: true
+    }
+
+    status, err = ssl_pg\connect!
+    assert.falsy status
+    assert.same [[the server does not support SSL connections]], err
+
   describe "with table", ->
     before_each ->
       assert pg\query [[


### PR DESCRIPTION
Hi,

A stab at SSL connections (#9).

Implements client-server SSL connection. We assume to be in an ngx_lua
environment, where 'tcpsock:sslhandshake()' is available. ngx_lua only
supports server authentication via 'lua_ssl_trusted_certificate'.

In plain Lua/JIT, we rely on LuaSec (the same way we rely on LuaSocket
already) and a fallback method is provided which follows the ngx_lua
method signature, plus accept LuaSec options. LuaSec allows for server
and client authentication.

An option is provided to require that the server supports SSL,
otherwise, aborts the connection, as suggested in section [43.2.9](http://www.postgresql.org/docs/8.1/static/protocol-flow.html#AEN60579) of the
protocol flow.

New options (defaults):

```lua
{
  ssl = false,
  ssl_verify = false,
  ssl_required = false,
  cafile = nil, -- LuaSec
  cert = nil, -- LuaSec
  key = nil -- LuaSec
}
```

From those options, only `ssl` is included as a class attribute for simplicity 
(is `ssl` is `false`, none of those options make sense), not sure if they should 
all be there or not.

Caveats:

- One change had to be done: the LuaSocket proxy metatable does not
  cache its original methods anymore. If it does, the old socket is
  retained from previous calls to 'send()' or 'receive()', and since
  LuaSec closes the socket when wrapping it, further calls do not
  succeed anymore.
- Not easily testable in CI and test suite. I added a simple test,
  but `ssl_required` and other options are harder to test on Travis. I
  tested all options manually with Lua and ngx_lua, on a server that
  does not accept non-SSL connections.

Usage:

```lua
local pgmoon = require "pgmoon"
local pg = pgmoon.new {
  ssl = true,
  ssl_verify = true,
  ssl_required = true,
  cafile = "/path/to/ca.pem"
  -- cert
  -- key
}

assert(pg:connect())

pg:disconnect()
```

Let me know!