### PR TITLE
hstore type encoding and decoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,33 @@ local my_tbl = {hello = "world"}
 pg:query("insert into some_table (some_json_col) values(" .. encode_json(my_tbl) .. ")")
 ```
 
+## Handling hstore
+
+the `hstore` type is automatically decoded if the hstore oid is set on the pg table
+
+```lua
+local pgmoon = require("pgmoon")
+local pg = pgmoon.new(auth)
+pg:connect()
+local res = pg.query("SELECT oid FROM pg_type WHERE typname = 'hstore'")
+pg:set_hstore_oid(tonumber(res[1].oid))
+```
+
+Use `encode_hstore` to encode a Lua table into hstore syntax:
+
+```lua
+local encode_hstore = require("pgmoon.hstore").encode_hstore
+local tbl = {foo = "bar"}
+pg:query("insert into some_table (hstore_col) values(" .. encode_hstore(tbl) .. ")")
+```
+Use `decode_hstore` to decode hstore syntax into a Lua table.  Useful if you don't set the hstore oid:
+
+```lua
+local decode_hstore = require("pgmoon.hstore").decode_hstore
+local res = pg:query("select * from some_table")
+local hstore_tbl = decode_hstore(res[1].hstore_col)
+```
+
 ## Converting `NULL`s
 
 By default `NULL`s in Postgres are converted to `nil`, meaning they aren't

--- a/pgmoon-dev-1.rockspec
+++ b/pgmoon-dev-1.rockspec
@@ -25,6 +25,7 @@ build = {
     ["pgmoon"] = "pgmoon/init.lua",
     ["pgmoon.arrays"] = "pgmoon/arrays.lua",
     ["pgmoon.crypto"] = "pgmoon/crypto.lua",
+    ["pgmoon.hstore"] = "pgmoon/hstore.lua",
     ["pgmoon.json"] = "pgmoon/json.lua",
     ["pgmoon.socket"] = "pgmoon/socket.lua",
   },

--- a/pgmoon/hstore.lua
+++ b/pgmoon/hstore.lua
@@ -1,0 +1,73 @@
+local PostgresHstore
+do
+  local _class_0
+  local _base_0 = { }
+  _base_0.__index = _base_0
+  _class_0 = setmetatable({
+    __init = function() end,
+    __base = _base_0,
+    __name = "PostgresHstore"
+  }, {
+    __index = _base_0,
+    __call = function(cls, ...)
+      local _self_0 = setmetatable({}, _base_0)
+      cls.__init(_self_0, ...)
+      return _self_0
+    end
+  })
+  _base_0.__class = _class_0
+  PostgresHstore = _class_0
+end
+getmetatable(PostgresHstore).__call = function(self, t)
+  return setmetatable(t, self.__base)
+end
+local encode_hstore
+do
+  encode_hstore = function(tbl, escape_literal)
+    escape_literal = escape_literal or default_escape_literal
+    if not (escape_literal) then
+      local Postgres
+      Postgres = require("pgmoon").Postgres
+      local default_escape_literal
+      default_escape_literal = function(v)
+        return Postgres.escape_literal(nil, v)
+      end
+      escape_literal = default_escape_literal
+    end
+    local buffer = { }
+    for k, v in pairs(tbl) do
+      table.insert(buffer, '"' .. k .. '"=>"' .. v .. '"')
+    end
+    return escape_literal(table.concat(buffer, ", "))
+  end
+end
+local decode_hstore
+do
+  local P, R, S, V, Ct, C, Cs, Cg, Cf
+  do
+    local _obj_0 = require("lpeg")
+    P, R, S, V, Ct, C, Cs, Cg, Cf = _obj_0.P, _obj_0.R, _obj_0.S, _obj_0.V, _obj_0.Ct, _obj_0.C, _obj_0.Cs, _obj_0.Cg, _obj_0.Cf
+  end
+  local g = P({
+    "hstore",
+    hstore = Cf(Ct("") * (V("pair") * (V("delim") * V("pair")) ^ 0) ^ -1, rawset),
+    pair = Cg(V("value") * "=>" * (V("value") + V("null"))),
+    value = V("invalid_char") + V("string"),
+    string = P('"') * Cs((P([[\\]]) / [[\]] + P([[\"]]) / [["]] + (P(1) - P('"'))) ^ 0) * P('"'),
+    null = C('NULL'),
+    invalid_char = S(" \t\r\n") / function()
+      return error("got unexpected whitespace")
+    end,
+    delim = P(", ")
+  })
+  decode_hstore = function(str, convert_fn)
+    local out = (assert(g:match(str), "failed to parse postgresql hstore"))
+    setmetatable(out, PostgresHstore.__base)
+    return out
+  end
+end
+return {
+  encode_hstore = encode_hstore,
+  decode_hstore = decode_hstore,
+  PostgresHstore = PostgresHstore
+}

--- a/pgmoon/hstore.moon
+++ b/pgmoon/hstore.moon
@@ -1,0 +1,53 @@
+
+class PostgresHstore
+
+getmetatable(PostgresHstore).__call = (t) =>
+  setmetatable t, @__base
+
+encode_hstore = do
+  (tbl, escape_literal) ->
+    escape_literal or= default_escape_literal
+
+    unless escape_literal
+      import Postgres from require "pgmoon"
+      default_escape_literal = (v) ->
+        Postgres.escape_literal nil, v
+
+      escape_literal = default_escape_literal
+
+    buffer = {}
+    for k, v in pairs(tbl)
+      table.insert buffer, '"' .. k .. '"=>"' .. v .. '"'
+
+    escape_literal table.concat buffer, ", "
+
+decode_hstore = do
+  import P, R, S, V, Ct, C, Cs, Cg, Cf from require "lpeg"
+  g = P {
+    "hstore"
+
+    hstore: Cf(Ct("") * (V"pair" * (V"delim" * V"pair")^0)^-1, rawset)
+    pair: Cg(V"value" * "=>" * (V"value" + V"null"))
+    value: V"invalid_char" + V"string"
+
+    string: P'"' * Cs(
+      (P([[\\]]) / [[\]] + P([[\"]]) / [["]] + (P(1) - P'"'))^0
+    ) * P'"'
+
+    null: C'NULL'
+
+    invalid_char: S" \t\r\n" / -> error "got unexpected whitespace"
+
+    delim: P", "
+  }
+
+  (str, convert_fn) ->
+    out = (assert g\match(str), "failed to parse postgresql hstore")
+    setmetatable out, PostgresHstore.__base
+
+    out
+
+
+
+{ :encode_hstore, :decode_hstore, :PostgresHstore }
+

--- a/pgmoon/init.lua
+++ b/pgmoon/init.lua
@@ -158,8 +158,18 @@ do
         local decode_json
         decode_json = require("pgmoon.json").decode_json
         return decode_array(val, decode_json)
+      end,
+      hstore = function(self, val, name)
+        local decode_hstore
+        decode_hstore = require("pgmoon.hstore").decode_hstore
+        return decode_hstore(val)
       end
     },
+    set_hstore_oid = function(self, oid)
+      if oid then
+        PG_TYPES[tonumber(oid)] = "hstore"
+      end
+    end,
     connect = function(self)
       self.sock = socket.new()
       local ok, err = self.sock:connect(self.host, self.port)

--- a/pgmoon/init.moon
+++ b/pgmoon/init.moon
@@ -132,7 +132,15 @@ class Postgres
       import decode_array from require "pgmoon.arrays"
       import decode_json from require "pgmoon.json"
       decode_array val, decode_json
+
+    hstore: (val, name) =>
+      import decode_hstore from require "pgmoon.hstore"
+      decode_hstore val
   }
+
+  set_hstore_oid: (oid) =>
+    if oid
+      PG_TYPES[tonumber(oid)] = "hstore"
 
   new: (opts) =>
     if opts

--- a/spec/pgmoon_spec.moon
+++ b/spec/pgmoon_spec.moon
@@ -301,7 +301,8 @@ describe "pgmoon with server", ->
       it "encodes multiple pairs", ->
         t = { foo: "bar", abc: "123" }
         enc = encode_hstore t
-        assert.same [['"foo"=>"bar", "abc"=>"123"']], enc
+        results = {'\'"foo"=>"bar", "abc"=>"123"\'', '\'"abc"=>"123", "foo"=>"bar"\''}
+        assert(enc == results[1] or enc == results[2])
 
       it "escapes", ->
         t = { foo: "bar's" }


### PR DESCRIPTION
Hello!

This will help with going to and from Lua tables and postgres hstore syntax.  Unfortunately since hstore is an extension the type oid needs to be set for automatic serialization.  I provided a way to do it but happy to get your feedback on what you think.  

Thanks again for this great library!
-edan