### PR TITLE
feat(pg) support for setting socket timeout

### DIFF
--- a/pgmoon/init.lua
+++ b/pgmoon/init.lua
@@ -161,7 +161,6 @@ do
       end
     },
     connect = function(self)
-      self.sock = socket.new()
       local ok, err = self.sock:connect(self.host, self.port)
       if not (ok) then
         return nil, err
@@ -189,6 +188,9 @@ do
         end
       end
       return true
+    end,
+    settimeout = function(self, ...)
+      return self.sock:settimeout(...)
     end,
     disconnect = function(self)
       local sock = self.sock
@@ -633,6 +635,7 @@ do
   _base_0.__index = _base_0
   _class_0 = setmetatable({
     __init = function(self, opts)
+      self.sock = socket.new()
       if opts then
         self.user = opts.user
         self.host = opts.host

--- a/pgmoon/init.moon
+++ b/pgmoon/init.moon
@@ -135,6 +135,7 @@ class Postgres
   }
 
   new: (opts) =>
+    @sock = socket.new!
     if opts
       @user = opts.user
       @host = opts.host
@@ -151,7 +152,6 @@ class Postgres
       }
 
   connect: =>
-    @sock = socket.new!
     ok, err = @sock\connect @host, @port
     return nil, err unless ok
 
@@ -170,6 +170,9 @@ class Postgres
       return nil, err unless success
 
     true
+
+  settimeout: (...) =>
+    @sock\settimeout ...
 
   disconnect: =>
     sock = @sock

--- a/pgmoon/socket.lua
+++ b/pgmoon/socket.lua
@@ -37,7 +37,8 @@ do
   local overrides = {
     send = true,
     getreusedtimes = true,
-    sslhandshake = true
+    sslhandshake = true,
+    settimeout = true
   }
   luasocket = {
     tcp = function(...)
@@ -50,6 +51,12 @@ do
         end,
         getreusedtimes = function(self)
           return 0
+        end,
+        settimeout = function(self, t)
+          if t then
+            t = t / 1000
+          end
+          return self.sock:settimeout(t)
         end,
         sslhandshake = function(self, _, _, verify, _, opts)
           if opts == nil then

--- a/pgmoon/socket.moon
+++ b/pgmoon/socket.moon
@@ -31,7 +31,8 @@ luasocket = do
   overrides = {
     send: true
     getreusedtimes: true
-    sslhandshake: true
+    sslhandshake: true,
+    settimeout: true
   }
 
   {
@@ -42,6 +43,10 @@ luasocket = do
         :sock
         send: (...) => @sock\send _flatten ...
         getreusedtimes: => 0
+        settimeout: (t) =>
+          if t
+            t = t/1000
+          @sock\settimeout t
         sslhandshake: (_, _, verify, _, opts={}) =>
           ssl = require "ssl"
           params = {

--- a/spec/pgmoon_spec.moon
+++ b/spec/pgmoon_spec.moon
@@ -37,6 +37,17 @@ describe "pgmoon with server", ->
 
     assert.same true, res
 
+  it "settimeout()", ->
+    timeout_pg = Postgres {
+      host: "10.0.0.1"
+    }
+
+    timeout_pg\settimeout 1000
+
+    ok, err = timeout_pg\connect!
+    assert.is_nil ok
+    assert.equal "timeout", err
+
   it "tries to connect with SSL", ->
     -- we expect a server with ssl = off
     ssl_pg = Postgres {


### PR DESCRIPTION
Add a wrapper for cosockets' `settimeout()` function. When using
LuaSocket, we make sure to divide the given value since the precision is
'seconds'.

* add `settimeout` override function to LuaSocket's proxy table
* create socket in `new()`, so users have a chance to set the timeout
  before the connection