### PR TITLE
checked in file dist.ini for OPM packaging.

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -1,0 +1,10 @@
+name=pgmoon
+abstract=A PostgreSQL client library written in pure Lua (MoonScript)
+author=Leaf Corcoran (leafo)
+is_original=yes
+license=mit
+lib_dir=.
+doc_dir=.
+repo_link=https://github.com/leafo/pgmoon
+main_module=pgmoon/init.lua
+exclude_files=lint_config.lua


### PR DESCRIPTION
OpenResty now has its own package management system, OPM. Let's add dist.ini for uploading to the [opm.openresty.org](https://opm.openresty.org) server :)