### PR TITLE
fix(ssl) use proper sslhandshake signature in ngx_lua

### DIFF
--- a/pgmoon/init.lua
+++ b/pgmoon/init.lua
@@ -576,7 +576,11 @@ do
         return nil, err
       end
       if t == MSG_TYPE.status then
-        return self.sock:sslhandshake(false, nil, self.ssl_verify, nil, self.luasec_opts)
+        if self.sock_type == "nginx" then
+          return self.sock:sslhandshake(false, nil, self.ssl_verify)
+        else
+          return self.sock:sslhandshake(self.ssl_verify, self.luasec_opts)
+        end
       elseif t == MSG_TYPE.error or self.ssl_required then
         self:disconnect()
         return nil, "the server does not support SSL connections"

--- a/pgmoon/init.moon
+++ b/pgmoon/init.moon
@@ -521,7 +521,10 @@ class Postgres
     return nil, err unless t
 
     if t == MSG_TYPE.status
-      @sock\sslhandshake false, nil, @ssl_verify, nil, @luasec_opts
+      if @sock_type == "nginx"
+        @sock\sslhandshake false, nil, @ssl_verify
+      else
+        @sock\sslhandshake @ssl_verify, @luasec_opts
     elseif t == MSG_TYPE.error or @ssl_required
       @disconnect!
       nil, "the server does not support SSL connections"

--- a/pgmoon/socket.lua
+++ b/pgmoon/socket.lua
@@ -42,7 +42,7 @@ do
           end
           return self.sock:settimeout(t)
         end,
-        sslhandshake = function(self, _, _, verify, _, opts)
+        sslhandshake = function(self, verify, opts)
           if opts == nil then
             opts = { }
           end

--- a/pgmoon/socket.moon
+++ b/pgmoon/socket.moon
@@ -34,7 +34,7 @@ luasocket = do
           if t
             t = t/1000
           @sock\settimeout t
-        sslhandshake: (_, _, verify, _, opts={}) =>
+        sslhandshake: (verify, opts={}) =>
           ssl = require "ssl"
           params = {
             mode: "client"


### PR DESCRIPTION
ngx_lua's API being quite strict, it refuses additional arguments to
most of its function and errors out instead of discarding them like it
is mostly the case for the standard Lua library functions.

A related discussion on the topic can be found at:
https://github.com/openresty/lua-nginx-module/pull/850

Fix #39