### PR TITLE
pg:keepalive() should not invalidate the socket reference

### DIFF
--- a/pgmoon/init.lua
+++ b/pgmoon/init.lua
@@ -229,7 +229,6 @@ do
     end,
     keepalive = function(self, ...)
       local sock = self.sock
-      self.sock = nil
       return sock:setkeepalive(...)
     end,
     auth = function(self)

--- a/pgmoon/init.moon
+++ b/pgmoon/init.moon
@@ -206,7 +206,6 @@ class Postgres
 
   keepalive: (...) =>
     sock = @sock
-    @sock = nil
     sock\setkeepalive ...
 
   auth: =>


### PR DESCRIPTION
pg:keepalive() calls down to the OpenResty socket connection for
reuse in the connection pool, however the reference should still
be made available for subsequent calls to pg:connect.