### PR TITLE
Bigint (int8) tweaks (#48)

### DIFF
--- a/pgmoon/init.lua
+++ b/pgmoon/init.lua
@@ -62,6 +62,14 @@ flipped = function(t)
   end
   return t
 end
+local int8_serialization
+int8_serialization = function()
+  if 9223372036854775807 - 1 == 9223372036854775807 then
+    return "string"
+  else
+    return "number"
+  end
+end
 local MSG_TYPE = flipped({
   status = "S",
   auth = "R",
@@ -89,7 +97,7 @@ local ERROR_TYPES = flipped({
 local PG_TYPES = {
   [16] = "boolean",
   [17] = "bytea",
-  [20] = "number",
+  [20] = int8_serialization(),
   [21] = "number",
   [23] = "number",
   [700] = "number",

--- a/pgmoon/init.moon
+++ b/pgmoon/init.moon
@@ -32,6 +32,13 @@ flipped = (t) ->
     t[t[key]] = key
   t
 
+int8_serialization = ->
+  -- Lua prior to v5.3 does not support 64-bit integers
+  if 9223372036854775807 - 1 == 9223372036854775807  -- Lua <= 5.2
+    return "string"
+  else  -- Lua >= 5.3
+    return "number"
+
 MSG_TYPE = flipped {
   status: "S"
   auth: "R"
@@ -65,7 +72,7 @@ PG_TYPES = {
   [16]: "boolean"
   [17]: "bytea"
 
-  [20]: "number" -- int8
+  [20]: int8_serialization! -- int8
   [21]: "number" -- int2
   [23]: "number" -- int4
   [700]: "number" -- float4

--- a/spec/pgmoon_spec.moon
+++ b/spec/pgmoon_spec.moon
@@ -271,6 +271,7 @@ describe "pgmoon with server", ->
         assert pg\query [[
           create table types_test (
             id serial not null,
+            largenum bigint default 9223372036854775807,
             name text default 'hello',
             subname varchar default 'world',
             count integer default 100,
@@ -294,9 +295,14 @@ describe "pgmoon with server", ->
           select * from types_test order by id asc limit 1
         ]]
 
+        largenum = "9223372036854775807"
+        if 9223372036854775807 - 1 == 9223372036854775807  -- No 64-bit int support in Lua
+          largenum = tonumber(largenum)
+
         assert.same {
           {
             id: 1
+            largenum: largenum  -- int8 result depends on 64-bit support in Lua
             name: "hello"
             subname: "world"
             count: 100

--- a/spec/pgmoon_spec.moon
+++ b/spec/pgmoon_spec.moon
@@ -296,7 +296,7 @@ describe "pgmoon with server", ->
         ]]
 
         largenum = "9223372036854775807"
-        if 9223372036854775807 - 1 == 9223372036854775807  -- No 64-bit int support in Lua
+        if 9223372036854775807 - 1 ~= 9223372036854775807  -- 64-bit int support in Lua
           largenum = tonumber(largenum)
 
         assert.same {


### PR DESCRIPTION
Addresses Issue #48

For versions of Lua that do not support 64-bit int (int8), serialize as a string. Otherwise leave as a 64-bit integer value.

Lua <= 5.2 does not support 64-bit integers, internally managing floating point values. For smaller values this is not noticeable. When serializing int8 columns containing larger values—e.g., 10^15—earlier versions of Lua will display exponent notation instead of the full value. Some slightly smaller values may appear correct but will have rounded values depending on the floating point mantissa.