### PR TITLE
Allow for TLS v1.2 when using LuaSec (not OpenResty)

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ local pg = pgmoon.new({
   ssl = true, -- enable SSL
   ssl_verify = true, -- verify server certificate
   ssl_required = true, -- abort if the server does not support SSL connections
+  ssl_version = "tlsv1", -- e.g., "tlsv1_2"; defaults to TLS v1.0 (LuaSec only)
   cafile = "...", -- certificate authority (LuaSec only)
   cert = "...", -- client certificate (LuaSec only)
   key = "...", -- client key (LuaSec only)

--- a/pgmoon/socket.lua
+++ b/pgmoon/socket.lua
@@ -49,7 +49,7 @@ do
           local ssl = require("ssl")
           local params = {
             mode = "client",
-            protocol = "tlsv1",
+            protocol = opts.ssl_version or "tlsv1",
             key = opts.key,
             certificate = opts.cert,
             cafile = opts.cafile,

--- a/pgmoon/socket.moon
+++ b/pgmoon/socket.moon
@@ -38,7 +38,7 @@ luasocket = do
           ssl = require "ssl"
           params = {
             mode: "client"
-            protocol: "tlsv1"
+            protocol: opts.ssl_version or "tlsv1"
             key: opts.key
             certificate: opts.cert
             cafile: opts.cafile

--- a/spec/pgmoon_ssl_spec.moon
+++ b/spec/pgmoon_ssl_spec.moon
@@ -25,7 +25,7 @@ describe "pgmoon with server", ->
     assert pg\query "select * from information_schema.tables"
     pg\disconnect!
 
-  it "connects with ssl on ssl server", ->
+  it "connects with ssl on ssl server (defaults to TLS v1.0)", ->
     pg = Postgres {
       database: DB
       port: PORT
@@ -39,5 +39,34 @@ describe "pgmoon with server", ->
     assert pg\query "select * from information_schema.tables"
     pg\disconnect!
 
+  it "connects with TLS v1.0 on ssl server", ->
+    pg = Postgres {
+      database: DB
+      port: PORT
+      user: USER
+      host: HOST
+      ssl: true
+      ssl_required: true
+      ssl_version: "tlsv1"
+    }
+
+    assert pg\connect!
+    assert pg\query "select * from information_schema.tables"
+    pg\disconnect!
+
+  it "connects with TLS v1.2 on ssl server", ->
+    pg = Postgres {
+      database: DB
+      port: PORT
+      user: USER
+      host: HOST
+      ssl: true
+      ssl_required: true
+      ssl_version: "tlsv1_2"
+    }
+
+    assert pg\connect!
+    assert pg\query "select * from information_schema.tables"
+    pg\disconnect!
 
 


### PR DESCRIPTION
Adds `ssl_version` option to user configuration. Kept default TLS version at 1.0 for backward compatibility but allow for user-specified version going forward, e.g., `"tlsv1_2"`. This parameter only applies to LuaSec installations—not OpenResty, which uses the Nginx Lua module built-ins for secure socket communication.

Fixes #57 for non-OpenResty case.