### PR TITLE
Opt for luaossl, if available - fallback to luacrypto

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ pgmoon is a PostgreSQL client library written in pure Lua (MoonScript).
 pgmoon was originally designed for use in [OpenResty][5] to take advantage of
 the [cosocket api][4] to provide asynchronous queries but it also works in the
 regular Lua environment as well using [LuaSocket][1] (and optionally
-[LuaCrypto][2] for MD5 authentication and [LuaSec][6] for SSL connections).
+[LuaCrypto][2] or [luaossl][8] for MD5 authentication and [LuaSec][6] for SSL connections).
 pgmoon can also use [cqueues][]' socket when passed `"cqueues"` as the socket
 type when instantiating.
 
@@ -383,4 +383,5 @@ THE SOFTWARE.
   [5]: http://openresty.org/
   [6]: https://github.com/brunoos/luasec
   [7]: https://github.com/openresty/lua-nginx-module#lua_ssl_trusted_certificate
+  [8]: http://25thandclement.com/~william/projects/luaossl.html
   [cqueues]: http://25thandclement.com/~william/projects/cqueues.html

--- a/pgmoon/crypto.lua
+++ b/pgmoon/crypto.lua
@@ -3,10 +3,23 @@ if ngx then
     md5 = ngx.md5
   }
 end
-local crypto = require("crypto")
-local md5
-md5 = function(str)
-  return crypto.digest("md5", str)
+local digest = require("openssl.digest")
+local md5 = nil
+if digest then
+  local to_hex
+  to_hex = function(str)
+    return string.gsub(str, '.', function(c)
+      return string.format("%02x", string.byte(c))
+    end)
+  end
+  md5 = function(str)
+    return to_hex(digest.new("md5"):final(str))
+  end
+else
+  local crypto = require("crypto")
+  md5 = function(str)
+    return crypto.digest("md5", str)
+  end
 end
 return {
   md5 = md5

--- a/pgmoon/crypto.moon
+++ b/pgmoon/crypto.moon
@@ -2,9 +2,20 @@
 if ngx
   return { md5: ngx.md5 }
 
-crypto = require "crypto"
+digest = require "openssl.digest"
 
-md5 = (str) ->
-  crypto.digest "md5", str
+md5 = nil
+
+if digest
+  to_hex = (str) ->
+    string.gsub str, '.', (c) ->
+      string.format "%02x", string.byte c
+
+  md5 = (str) ->
+    to_hex digest.new("md5")\final(str)
+else
+  crypto = require "crypto"
+  md5 = (str) ->
+    crypto.digest "md5", str
 
 { :md5 }


### PR DESCRIPTION
Now that Lapis 1.6.0 uses luaossl, I figured it would make sense for pgmoon to use luaossl, if available.

Luacrypto is still available as a fallback, so hopefully this shouldn't impact existing installs.