### PR TITLE
Add luacrypto dependency

### DIFF
--- a/pgmoon-dev-1.rockspec
+++ b/pgmoon-dev-1.rockspec
@@ -17,6 +17,7 @@ dependencies = {
   "lua >= 5.1",
   "luabitop",
   "lpeg",
+  "luacrypto",
 }
 
 build = {


### PR DESCRIPTION
In `pgmoon.crypto`, luacrypto gets required if pgmoon isn't running under openresty but it is not listed as a dependency. Since lapis migrate doesn't run in the openresty environment, it fails every time.