### PR TITLE
add method isconnected to detect if the inner sock is connected.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ message.
 Closes the socket to the server if one is open. No other methods should be
 called on the object after this other than another call to connect.
 
+### connected = postgres:isconnected()
+
+Returns true if the socket to the server is connected. Returns false if not.
 
 ### success, err = postgres:keepalive(...)
 

--- a/pgmoon/init.lua
+++ b/pgmoon/init.lua
@@ -222,6 +222,9 @@ do
     settimeout = function(self, ...)
       return self.sock:settimeout(...)
     end,
+    isconnected = function(self)
+      return self.sock ~= nil
+    end,
     disconnect = function(self)
       local sock = self.sock
       self.sock = nil

--- a/pgmoon/init.moon
+++ b/pgmoon/init.moon
@@ -199,6 +199,9 @@ class Postgres
   settimeout: (...) =>
     @sock\settimeout ...
 
+  isconnected: =>
+    @sock != nil
+
   disconnect: =>
     sock = @sock
     @sock = nil

--- a/spec/pgmoon_spec.moon
+++ b/spec/pgmoon_spec.moon
@@ -656,7 +656,8 @@ describe "pgmoon with server", ->
         assert.same [[FATAL: database "doesnotexist" does not exist]], err
 
       teardown ->
-        pg\disconnect!
+        if pg\isconnected
+          pg\disconnect!
         os.execute "dropdb -U postgres '#{DB}'"
 
 describe "pgmoon without server", ->


### PR DESCRIPTION
Sometimes we need to call 'disconnect' explicitly in db driver wrapper
module. But pgmoon will close the sock when sock operation failed. Thus
it is unsafe to call 'disconnect' again. With 'isconnected' method we
could detect if the sock is still connected, avoid calling 'disconnect'
twice.