### PR TITLE
fix 0xFFFFFFFF parsed as 4294967295 instead of -1 on 64bits systems

### DIFF
--- a/pgmoon/init.lua
+++ b/pgmoon/init.lua
@@ -465,7 +465,7 @@ do
           field_name, field_type = field[1], field[2]
           local len = self:decode_int(data_row:sub(offset, offset + 3))
           offset = offset + 4
-          if len < 0 then
+          if len < 0 or len == 4294967295 then
             if self.convert_null then
               out[field_name] = self.NULL
             end

--- a/pgmoon/init.moon
+++ b/pgmoon/init.moon
@@ -428,7 +428,7 @@ class Postgres
       len = @decode_int data_row\sub offset, offset + 3
       offset += 4
 
-      if len < 0
+      if len < 0 or len == 4294967295
         out[field_name] = @NULL if @convert_null
         continue
 


### PR DESCRIPTION
Depending on host implementation, the decode_int function returns 4294967295 instead of -1, thus resulting in undefined behaviors (offset overflow) when query results contain null fields.