### PR TITLE
fix: pass ssl_version to luasec_opts

### DIFF
--- a/pgmoon/init.lua
+++ b/pgmoon/init.lua
@@ -687,7 +687,8 @@ do
         self.luasec_opts = {
           key = opts.key,
           cert = opts.cert,
-          cafile = opts.cafile
+          cafile = opts.cafile,
+          ssl_version = opts.ssl_version
         }
       end
     end,

--- a/pgmoon/init.moon
+++ b/pgmoon/init.moon
@@ -169,6 +169,7 @@ class Postgres
         key: opts.key
         cert: opts.cert
         cafile: opts.cafile
+        ssl_version: opts.ssl_version
       }
 
   connect: =>


### PR DESCRIPTION
It seems like the `ssl_version` parameter is needed by the `luasec_opts`
table in order to do properly do the SSL handshake:
https://github.com/leafo/pgmoon/blob/v1.11.0/pgmoon/init.lua#L589

Otherwise we would get an error like the following when calling
`pg:connect()` to a server that accepts only TLS 1.2:

```
tlsv1 alert protocol version
```

Since the default is TLS 1.1: https://github.com/leafo/pgmoon/blob/v1.11.0/pgmoon/socket.lua#L52

With the introduction of version 12.x of Postgres, it gives you the
ability to set the min and max TLS version.

ssl_min_protocol_version:
https://www.postgresql.org/docs/12/runtime-config-connection.html#GUC-SSL-MIN-PROTOCOL-VERSION

ssl_max_protocol_version:
https://www.postgresql.org/docs/12/runtime-config-connection.html#GUC-SSL-MAX-PROTOCOL-VERSION

So if one sets `ssl_min_protocol_version` to `TLSv1.2` the above error
will be thrown.