### PR TITLE
travis updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,25 +7,34 @@ addons:
 
 env:
   global:
-    - LUAROCKS=2.3.0
+    - LUAROCKS=3.4.0
+    - LUACJSON=f8e36f8
   matrix:
-    - LUA=lua5.1
-    - LUA=lua5.2
-    - LUA=lua5.3
-    - LUA=luajit2.1
+    - LUA=lua5.1    LUA_32BITS=no
+    - LUA=lua5.2    LUA_32BITS=no
+    - LUA=lua5.3    LUA_32BITS=no
+    - LUA=lua5.4    LUA_32BITS=no
+    - LUA=lua5.3    LUA_32BITS=yes
+    - LUA=lua5.4    LUA_32BITS=yes
+    - LUA=luajit2.0 LUA_32BITS=no
+    - LUA=luajit2.1 LUA_32BITS=no
 
 before_install:
   - source .travis/setenv_lua.sh
 
 install:
+  - mkdir -p .lua-cjson
+  - curl -R -L https://github.com/openresty/lua-cjson/archive/${LUACJSON}.tar.gz | tar xzf - --strip-components=1 -C .lua-cjson
   - luarocks install busted
   - luarocks install luasocket
   - luarocks install luasec
   - luarocks install moonscript
-  - luarocks install lua-cjson
+  - pushd .lua-cjson && luarocks make && popd
   - luarocks install cqueues
-  - luarocks make
+  - test "$LUA" = "lua5.1" && luarocks install luabitop || true
+  - test "$LUA" = "lua5.2" && luarocks install luabitop || true
 
 script:
+  - luarocks make
   - busted
 

--- a/.travis/setup_lua.sh
+++ b/.travis/setup_lua.sh
@@ -51,6 +51,8 @@ if [ "$LUAJIT" == "yes" ]; then
     git checkout v2.1;
     # force the INSTALL_TNAME to be luajit
     perl -i -pe 's/INSTALL_TNAME=.+/INSTALL_TNAME= luajit/' Makefile
+  elif [ "$LUA" != "luajit" ] ; then
+    git checkout "v$(expr substr $LUA 7 9)"
   fi
 
   make && make install PREFIX="$LUA_HOME_DIR"
@@ -67,12 +69,20 @@ else
     curl http://www.lua.org/ftp/lua-5.2.4.tar.gz | tar xz
     cd lua-5.2.4;
   elif [ "$LUA" == "lua5.3" ]; then
-    curl http://www.lua.org/ftp/lua-5.3.2.tar.gz | tar xz
-    cd lua-5.3.2;
+    curl http://www.lua.org/ftp/lua-5.3.6.tar.gz | tar xz
+    cd lua-5.3.6;
+  elif [ "$LUA" == "lua5.4" ]; then
+    curl http://www.lua.org/ftp/lua-5.4.1.tar.gz | tar xz
+    cd lua-5.4.1;
   fi
 
   # Build Lua without backwards compatibility for testing
-  perl -i -pe 's/-DLUA_COMPAT_(ALL|5_2)//' src/Makefile
+  perl -i -pe 's/-DLUA_COMPAT_(ALL|5_2|5_3)//' src/Makefile
+
+  # build with 32-bit integers if requested
+  if [ "$LUA_32BITS" = "yes" ] ; then
+    perl -i -pe '$_ = "#define LUA_32BITS" if $_ =~ m/define LUA_32BITS/' src/luaconf.h
+  fi
   make $PLATFORM
   make INSTALL_TOP="$LUA_HOME_DIR" install;
 
@@ -118,5 +128,7 @@ elif [ "$LUA" == "lua5.1" ]; then
 elif [ "$LUA" == "lua5.2" ]; then
   rm -rf lua-5.2.4;
 elif [ "$LUA" == "lua5.3" ]; then
-  rm -rf lua-5.3.2;
+  rm -rf lua-5.3.6;
+elif [ "$LUA" == "lua5.4" ]; then
+  rm -rf lua-5.4.1;
 fi


### PR DESCRIPTION
Split out from #97 , updates for Travis

* Updates Lua 5.3
* Updates Luarocks
* Adds Lua 5.4
* Adds 32-bit builds of Lua 5.3 and Lua 5.4
* Uses latest lua-cjson module from git instead of luarocks
* Conditionally install luabitop (Lua 5.1 and Lua 5.2 only)
* Explicitly checks out the LuaJIT branch to be tested (upstream now
  defaults to 2.1, previously if LuaJIT 2.0 was requested it was actually
  testing against 2.1)