### PR TITLE
Make application_name pg client init param configurable

### DIFF
--- a/pgmoon/init.moon
+++ b/pgmoon/init.moon
@@ -173,6 +173,7 @@ class Postgres
         ssl_version: opts.ssl_version or "any"
         options: { "all", "no_sslv2", "no_sslv3", "no_tlsv1" }
       }
+      @application_name = opts.application_name or "pgmoon"
 
   connect: =>
     opts = if @sock_type == "nginx"
@@ -510,7 +511,7 @@ class Postgres
       "database", NULL
       @database, NULL
       "application_name", NULL
-      "pgmoon", NULL
+      @application_name, NULL
       NULL
     }
 


### PR DESCRIPTION
Allows client conns to specify a value for `application_name` instead of just hard-coding to `"pgmoon"`, e.g.:

```
    pg_settings = {
        host = ip,
        port = '5432',
        database = os.getenv('POSTGRES_DATABASE'),
        user = os.getenv('POSTGRES_USERNAME'),
        password = os.getenv('POSTGRES_PASSWORD'),
        application_name = 'api-gateway'  -- previously this was hardcoded to "pgmoon"
    }
```

@leafo I should just be able to run `make build` to generate the `*.lua` files correct?

Resolves #107.