### PR TITLE
pgmoon.crypto better support for resty.openssl / resty.string libraries

### DIFF
--- a/pgmoon/crypto.lua
+++ b/pgmoon/crypto.lua
@@ -53,10 +53,34 @@ else
   end
 end
 local digest_sha256
-digest_sha256 = function(str)
-  local digest = assert(require("openssl.digest").new("sha256"))
-  digest:update(str)
-  return assert(digest:final())
+if pcall(function()
+  return require("openssl.digest")
+end) then
+  digest_sha256 = function(str)
+    local digest = assert(require("openssl.digest").new("sha256"))
+    digest:update(str)
+    return assert(digest:final())
+  end
+elseif pcall(function()
+  return require("resty.sha256")
+end) then
+  digest_sha256 = function(str)
+    local digest = assert(require("resty.sha256"):new())
+    digest:update(str)
+    return assert(digest:final())
+  end
+elseif pcall(function()
+  return require("resty.openssl.digest")
+end) then
+  digest_sha256 = function(str)
+    local digest = assert(require("resty.openssl.digest").new("sha256"))
+    digest:update(str)
+    return assert(digest:final())
+  end
+else
+  digest_sha256 = function()
+    return error("Either luaossl or resty.openssl is required to calculate sha256 digest")
+  end
 end
 local kdf_derive_sha256
 if pcall(function()

--- a/pgmoon/crypto.lua
+++ b/pgmoon/crypto.lua
@@ -60,9 +60,28 @@ kdf_derive_sha256 = function(str, salt, i)
   end
   return key
 end
+local random_bytes
+if pcall(function()
+  return require("openssl.rand")
+end) then
+  random_bytes = require("openssl.rand").bytes
+elseif pcall(function()
+  return require("resty.random")
+end) then
+  random_bytes = require("resty.random").bytes
+elseif pcall(function()
+  return require("resty.openssl.rand")
+end) then
+  random_bytes = require("resty.openssl.rand").bytes
+else
+  random_bytes = function()
+    return error("Either luaossl or resty.openssl is required to generate random bytes")
+  end
+end
 return {
   md5 = md5,
   hmac_sha256 = hmac_sha256,
   digest_sha256 = digest_sha256,
-  kdf_derive_sha256 = kdf_derive_sha256
+  kdf_derive_sha256 = kdf_derive_sha256,
+  random_bytes = random_bytes
 }

--- a/pgmoon/crypto.lua
+++ b/pgmoon/crypto.lua
@@ -78,10 +78,31 @@ else
     return error("Either luaossl or resty.openssl is required to generate random bytes")
   end
 end
+local x509_digest
+if pcall(function()
+  return require("openssl.x509")
+end) then
+  local x509 = require("openssl.x509")
+  x509_digest = function(pem, hash_type)
+    return x509.new(pem, "PEM"):digest(hash_type, "s")
+  end
+elseif pcall(function()
+  return require("resty.openssl.x509")
+end) then
+  local x509 = require("resty.openssl.x509")
+  x509_digest = function(pem, hash_type)
+    return x509.new(pem, "PEM"):digest(hash_type)
+  end
+else
+  x509_digest = function()
+    return error("Either luaossl or resty.openssl is required to calculate x509 digest")
+  end
+end
 return {
   md5 = md5,
   hmac_sha256 = hmac_sha256,
   digest_sha256 = digest_sha256,
   kdf_derive_sha256 = kdf_derive_sha256,
-  random_bytes = random_bytes
+  random_bytes = random_bytes,
+  x509_digest = x509_digest
 }

--- a/pgmoon/crypto.lua
+++ b/pgmoon/crypto.lua
@@ -29,11 +29,28 @@ else
   end
 end
 local hmac_sha256
-hmac_sha256 = function(key, str)
-  local openssl_hmac = require("openssl.hmac")
-  local hmac = assert(openssl_hmac.new(key, "sha256"))
-  hmac:update(str)
-  return assert(hmac:final())
+if pcall(function()
+  return require("openssl.hmac")
+end) then
+  hmac_sha256 = function(key, str)
+    local openssl_hmac = require("openssl.hmac")
+    local hmac = assert(openssl_hmac.new(key, "sha256"))
+    hmac:update(str)
+    return assert(hmac:final())
+  end
+elseif pcall(function()
+  return require("resty.openssl.hmac")
+end) then
+  hmac_sha256 = function(key, str)
+    local openssl_hmac = require("resty.openssl.hmac")
+    local hmac = assert(openssl_hmac.new(key, "sha256"))
+    hmac:update(str)
+    return assert(hmac:final())
+  end
+else
+  hmac_sha256 = function()
+    return error("Either luaossl or resty.openssl is required to calculate hmac sha256 digest")
+  end
 end
 local digest_sha256
 digest_sha256 = function(str)

--- a/pgmoon/crypto.moon
+++ b/pgmoon/crypto.moon
@@ -13,12 +13,24 @@ elseif pcall -> require "crypto"
 else
   -> error "Either luaossl (recommended) or LuaCrypto is required to calculate md5"
 
-hmac_sha256 = (key, str) ->
-  openssl_hmac = require("openssl.hmac")
-  hmac = assert openssl_hmac.new(key, "sha256")
 
-  hmac\update str
-  assert hmac\final!
+hmac_sha256 = if pcall -> require "openssl.hmac"
+  (key, str) ->
+    openssl_hmac = require("openssl.hmac")
+    hmac = assert openssl_hmac.new(key, "sha256")
+
+    hmac\update str
+    assert hmac\final!
+elseif pcall -> require "resty.openssl.hmac"
+  (key, str) ->
+    openssl_hmac = require("resty.openssl.hmac")
+    hmac = assert openssl_hmac.new(key, "sha256")
+
+    hmac\update str
+    assert hmac\final!
+else
+  -> error "Either luaossl or resty.openssl is required to calculate hmac sha256 digest"
+
 
 digest_sha256 = (str) ->
   digest = assert require("openssl.digest").new("sha256")

--- a/pgmoon/crypto.moon
+++ b/pgmoon/crypto.moon
@@ -57,4 +57,14 @@ else
   -> error "Either luaossl or resty.openssl is required to generate random bytes"
 
 
-{ :md5, :hmac_sha256, :digest_sha256, :kdf_derive_sha256, :random_bytes }
+x509_digest = if pcall -> require "openssl.x509"
+  x509 = require "openssl.x509"
+  (pem, hash_type) -> x509.new(pem, "PEM")\digest(hash_type, "s")
+elseif pcall -> require "resty.openssl.x509"
+  x509 = require "resty.openssl.x509"
+  (pem, hash_type) -> x509.new(pem, "PEM")\digest(hash_type)
+else
+  -> error "Either luaossl or resty.openssl is required to calculate x509 digest"
+
+
+{ :md5, :hmac_sha256, :digest_sha256, :kdf_derive_sha256, :random_bytes, :x509_digest }

--- a/pgmoon/crypto.moon
+++ b/pgmoon/crypto.moon
@@ -32,10 +32,23 @@ else
   -> error "Either luaossl or resty.openssl is required to calculate hmac sha256 digest"
 
 
-digest_sha256 = (str) ->
-  digest = assert require("openssl.digest").new("sha256")
-  digest\update str
-  assert digest\final!
+digest_sha256 = if pcall -> require "openssl.digest"
+  (str) ->
+    digest = assert require("openssl.digest").new("sha256")
+    digest\update str
+    assert digest\final!
+elseif pcall -> require "resty.sha256"
+  (str) ->
+    digest = assert require("resty.sha256")\new()
+    digest\update str
+    assert digest\final!
+elseif pcall -> require "resty.openssl.digest"
+  (str) ->
+    digest = assert require("resty.openssl.digest").new("sha256")
+    digest\update str
+    assert digest\final!
+else
+  -> error "Either luaossl or resty.openssl is required to calculate sha256 digest"
 
 
 kdf_derive_sha256 = if pcall -> require "openssl.kdf"

--- a/pgmoon/crypto.moon
+++ b/pgmoon/crypto.moon
@@ -46,4 +46,15 @@ kdf_derive_sha256 = (str, salt, i) ->
 
   key
 
-{ :md5, :hmac_sha256, :digest_sha256, :kdf_derive_sha256 }
+
+random_bytes = if pcall -> require "openssl.rand"
+  require("openssl.rand").bytes
+elseif pcall -> require "resty.random"
+  require("resty.random").bytes
+elseif pcall -> require "resty.openssl.rand"
+  require("resty.openssl.rand").bytes
+else
+  -> error "Either luaossl or resty.openssl is required to generate random bytes"
+
+
+{ :md5, :hmac_sha256, :digest_sha256, :kdf_derive_sha256, :random_bytes }

--- a/pgmoon/init.lua
+++ b/pgmoon/init.lua
@@ -306,8 +306,9 @@ do
     end,
     scram_sha_256_auth = function(self, msg)
       assert(self.config.password, "missing password, required for connect")
-      local openssl_rand = require("openssl.rand")
-      local rand_bytes = assert(openssl_rand.bytes(18))
+      local random_bytes
+      random_bytes = require("pgmoon.crypto").random_bytes
+      local rand_bytes = assert(random_bytes(18))
       local encode_base64
       encode_base64 = require("pgmoon.util").encode_base64
       local c_nonce = encode_base64(rand_bytes)

--- a/pgmoon/init.lua
+++ b/pgmoon/init.lua
@@ -306,8 +306,11 @@ do
     end,
     scram_sha_256_auth = function(self, msg)
       assert(self.config.password, "missing password, required for connect")
-      local random_bytes
-      random_bytes = require("pgmoon.crypto").random_bytes
+      local random_bytes, x509_digest
+      do
+        local _obj_0 = require("pgmoon.crypto")
+        random_bytes, x509_digest = _obj_0.random_bytes, _obj_0.x509_digest
+      end
       local rand_bytes = assert(random_bytes(18))
       local encode_base64
       encode_base64 = require("pgmoon.util").encode_base64
@@ -358,8 +361,7 @@ do
             if signature:match("^md5") or signature:match("^sha1") then
               signature = "sha256"
             end
-            local openssl_x509 = require("openssl.x509").new(pem, "PEM")
-            cbind_data = assert(openssl_x509:digest(signature, "s"))
+            cbind_data = assert(x509_digest(pem, signature))
           end
         end
         cbind_input = gs2_header .. cbind_data

--- a/pgmoon/init.moon
+++ b/pgmoon/init.moon
@@ -298,10 +298,10 @@ class Postgres
   scram_sha_256_auth: (msg) =>
     assert @config.password, "missing password, required for connect"
 
-    openssl_rand = require "openssl.rand"
+    import random_bytes from require "pgmoon.crypto"
 
     -- '18' is the number set by postgres on the server side
-    rand_bytes  = assert openssl_rand.bytes 18
+    rand_bytes  = assert random_bytes 18
 
     import encode_base64 from require "pgmoon.util"
 

--- a/pgmoon/init.moon
+++ b/pgmoon/init.moon
@@ -298,7 +298,7 @@ class Postgres
   scram_sha_256_auth: (msg) =>
     assert @config.password, "missing password, required for connect"
 
-    import random_bytes from require "pgmoon.crypto"
+    import random_bytes, x509_digest from require "pgmoon.crypto"
 
     -- '18' is the number set by postgres on the server side
     rand_bytes  = assert random_bytes 18
@@ -356,8 +356,7 @@ class Postgres
           if signature\match("^md5") or signature\match("^sha1")
             signature = "sha256"
 
-          openssl_x509 = require("openssl.x509").new(pem, "PEM")
-          assert openssl_x509\digest(signature, "s")
+          assert x509_digest(pem, signature)
 
       cbind_input = gs2_header .. cbind_data
 


### PR DESCRIPTION
### Summary

- Adds `random_bytes` function to `pgmoon.crypto` compatibility layer and makes use of it in `pgmoon.init`
- Adds `x509_digest` function to `pgmoon.crypto` compatibility layer and makes use of it in `pgmoon.init`
- Adds `resty.openssl` support to `hmac_sha256`
- Adds `resty.openssl` and `resty.string` support to `digest_sha256`

We don't anymore ship `luaossl` with Kong and this causes our users issues with `scram-sha-256` authentication as reported in: https://github.com/Kong/kong/issues/8259

This PR fixes it so that it works with `resty.openssl` library too (the one that is shipped with Kong).