### PR TITLE
implement haproxy socket type from configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Functions in table returned by `require("pgmoon")`:
 
 Creates a new `Postgres` object from a configuration object. All fields are
 optional unless otherwise stated. The newly created object will not
-automatically connect, you must call `conect` after creating the object.
+automatically connect, you must call `connect` after creating the object.
 
 Available options:
 
@@ -139,7 +139,7 @@ Available options:
 * `"ssl"`: enable ssl (default: `false`)
 * `"ssl_verify"`: verify server certificate (default: `nil`)
 * `"ssl_required"`: abort the connection if the server does not support SSL connections (default: `nil`)
-* `"socket_type"`: the type of socket to use, one of: `"nginx"`, `"luasocket"`, `cqueues` (default: `"nginx"` if in nginx, `"luasocket"` otherwise)
+* `"socket_type"`: the type of socket to use, one of: `"nginx"`, `"haproxy"`, `"luasocket"`, `"cqueues"` (default: `"nginx"` if in nginx, `"haproxy"` if in haproxy, `"luasocket"` otherwise)
 * `"application_name"`: set the name of the connection as displayed in `pg_stat_activity`. (default: `"pgmoon"`)
 * `"pool"`: (OpenResty only) name of pool to use when using OpenResty cosocket (default: `"#{host}:#{port}:#{database}"`)
 * `"pool_size"`: (OpenResty only) Passed directly to OpenResty cosocket connect function, [see docs](https://github.com/openresty/lua-nginx-module#tcpsockconnect)

--- a/pgmoon/socket.lua
+++ b/pgmoon/socket.lua
@@ -89,6 +89,8 @@ return {
     if socket_type == nil then
       if ngx and ngx.get_phase() ~= "init" then
         socket_type = "nginx"
+      elseif core and core.get_info() then
+        socket_type = "haproxy"
       else
         socket_type = "luasocket"
       end
@@ -99,6 +101,8 @@ return {
       socket = ngx.socket.tcp()
     elseif "luasocket" == _exp_0 then
       socket = create_luasocket()
+    elseif "haproxy" == _exp_0 then
+      socket = core.tcp(...)
     elseif "cqueues" == _exp_0 then
       socket = require("pgmoon.cqueues").CqueuesSocket()
     else

--- a/pgmoon/socket.moon
+++ b/pgmoon/socket.moon
@@ -85,6 +85,8 @@ create_luasocket = do
       -- luasocket
       socket_type = if ngx and ngx.get_phase! != "init"
         "nginx"
+      elseif core and core.get_info!
+        "haproxy"
       else
         "luasocket"
 
@@ -93,6 +95,8 @@ create_luasocket = do
         ngx.socket.tcp!
       when "luasocket"
         create_luasocket!
+      when "haproxy"
+        core.tcp ...
       when "cqueues"
         require("pgmoon.cqueues").CqueuesSocket!
       else


### PR DESCRIPTION
When the Lua HAProxy `core` object is detected, the socket class will
automatically use its (non-blocking) socket type. The pattern is similar
to existing auto-detection of whether pgmoon is running inside an NGINX
context or not and choosing that socket type if so.

http://www.arpalert.org/src/haproxy-lua-api/1.7/index.html#core.get_info