### PR TITLE
use git+ssh protocol in rockspec source url

### DIFF
--- a/pgmoon-dev-1.rockspec
+++ b/pgmoon-dev-1.rockspec
@@ -2,7 +2,7 @@ package = "pgmoon"
 version = "dev-1"
 
 source = {
-  url = "git://github.com/leafo/pgmoon.git"
+  url = "git+https://github.com/leafo/pgmoon.git"
 }
 
 description = {


### PR DESCRIPTION
GitHub has stopped permitting usage of the unauthenticated git protocol
per [this blog post
announcement](https://github.blog/2021-09-01-improving-git-protocol-security-github/)
which also describes the brown/black out schedule.