### PR TITLE
set correct signarue digest name when using ECDSA cert

### DIFF
--- a/pgmoon/init.lua
+++ b/pgmoon/init.lua
@@ -401,9 +401,13 @@ do
               local server_cert = self.sock:getpeercertificate()
               pem, signature = server_cert:pem(), server_cert:getsignaturename()
             end
-            signature = signature:lower()
             if signature:match("^md5") or signature:match("^sha1") then
               signature = "sha256"
+            else
+              local objects = require("resty.openssl.objects")
+              local sigid = assert(objects.txt2nid(signature))
+              local digest_nid = assert(objects.find_sigid_algs(sigid))
+              signature = assert(objects.nid2table(digest_nid).sn)
             end
             cbind_data = assert(x509_digest(pem, signature))
           end


### PR DESCRIPTION
When using ECDSA certificate, the `signature` name is the full name (e.g., `ecdsa-with-SHA384`), but indeed should be the digest part only (e.g., `SHA384`).

This PR fixes the issue. Make sure `lua-resty-openssl` is bumped to `0.8.10`.