### PR TITLE
Add support for X509 signature algorithms such as RSA-SHA1 and ECDSA-with-SHA384

### DIFF
--- a/pgmoon/init.lua
+++ b/pgmoon/init.lua
@@ -402,7 +402,12 @@ do
               pem, signature = server_cert:pem(), server_cert:getsignaturename()
             end
             signature = signature:lower()
-            if signature:match("^md5") or signature:match("^sha1") then
+            local _, with_sig
+            _, _, with_sig = signature:find("%-with%-(.*)")
+            if with_sig then
+              signature = with_sig
+            end
+            if signature:match("^md5") or signature:match("^sha1") or signature:match("sha1$") then
               signature = "sha256"
             end
             cbind_data = assert(x509_digest(pem, signature))

--- a/pgmoon/init.moon
+++ b/pgmoon/init.moon
@@ -406,8 +406,13 @@ class Postgres
 
           signature = signature\lower!
 
-          -- upgrade the signature if necessary
-          if signature\match("^md5") or signature\match("^sha1")
+          -- Handle the case when the signature is e.g. ECDSA-with-SHA384
+          _, _, with_sig = signature\find("%-with%-(.*)")
+          if with_sig
+            signature = with_sig
+
+          -- upgrade the signature if necessary (also handle the case of s/RSA-SHA1/sha256)
+          if signature\match("^md5") or signature\match("^sha1") or signature\match("sha1$")
             signature = "sha256"
 
           assert x509_digest(pem, signature)

--- a/spec/docker_enable_ssl.sh
+++ b/spec/docker_enable_ssl.sh
@@ -11,7 +11,7 @@ ls -lah >&2
 openssl req -new -passout pass:itchzone -text -out server.req -subj "/C=US/ST=Leafo/L=Leafo/O=Leafo/CN=itch.zone"
 openssl rsa -passin pass:itchzone -in privkey.pem -out server.key
 rm privkey.pem
-openssl req -x509 -in server.req -text -key server.key -out server.crt
+openssl req -x509 -sha1 -in server.req -text -key server.key -out server.crt
 chmod og-rwx server.key
 
 # TLSv1 min version to mimic older versions of postgres

--- a/spec/pgmoon_spec.moon
+++ b/spec/pgmoon_spec.moon
@@ -174,6 +174,7 @@ describe "pgmoon with server", ->
         errors = {
           "timeout": true
           "Connection timed out": true
+          "Operation timed out": true
         }
 
         assert.true errors[err]

--- a/spec/postgres.sh
+++ b/spec/postgres.sh
@@ -14,7 +14,7 @@ function makecerts {
     openssl req -new -passout pass:itchzone -text -out server.req -subj "/C=US/ST=Leafo/L=Leafo/O=Leafo/CN=itch.zone"
     openssl rsa -passin pass:itchzone -in privkey.pem -out server.key
     rm privkey.pem
-    openssl req -x509 -in server.req -text -key server.key -out server.crt
+    openssl req -x509 -sha1 -in server.req -text -key server.key -out server.crt
     chmod og-rwx server.key
   )
 }


### PR DESCRIPTION
When using ECDSA certificate, the signature name is the full name (e.g., ecdsa-with-SHA384), but indeed should be the digest part only (e.g., SHA384). Similarly, RSA-SHA1 is broken now because it doesn't start with SHA1 hence it doesn't get replace with SHA256.

This PR fixes both of these problems.
It's an alternative proposal to https://github.com/leafo/pgmoon/pull/127 that works for all socket types but I didn't touch cqueues because I was not sure why it was hardcoded as SHA256.