### PR TITLE
Fix set_type_deserializer example

### DIFF
--- a/README.md
+++ b/README.md
@@ -615,7 +615,7 @@ local pg = pgmoon.new(config)
 
 -- in this example we create a new deserializer called bignumber and provide
 -- the function to deserialize (type OID 20 is an 8 byte integer)
-pg:set_type_deserializer(20, "bignumber", function(val)
+pg:set_type_deserializer(20, "bignumber", function(self, val)
     return "HUGENUMBER:" .. val
 end)
 


### PR DESCRIPTION
The first argument to the deserializer function is `self`, not the
actual value: https://github.com/leafo/pgmoon/blob/7b7ef2a3f17d32881c61f0fb258d2ee01718942c/pgmoon/init.lua#L850