### PR TITLE
Fix syntax error with example

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ local pg = pgmoon.new({
 
 assert(pg:connect())
 
-local res = assert(pg:query("select * from users where status = 'active' limit 20")
+local res = assert(pg:query("select * from users where status = 'active' limit 20"))
 
 assert(pg:query("update users set name = $1 where id = $2", "leafo", 99))
 


### PR DESCRIPTION
Currently errors with `lua: example.lua:13: ')' expected (to close '(' at line 11) near 'assert'`